### PR TITLE
RFC: virt: Add an 'immediate' mode for panicking on certain VpHaltReasons

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3027,6 +3027,9 @@ async fn new_underhill_vm(
         ),
     );
 
+    #[cfg(not(debug_assertions))]
+    virt::PANIC_ON_FAILURE_CONSTRUCTION.store(true, std::sync::atomic::Ordering::Relaxed);
+
     let (mut partition_unit, vp_runners) = PartitionUnit::new(
         tp,
         state_units

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -63,6 +63,7 @@ use virt::ProtoPartition;
 use virt::ProtoPartitionConfig;
 use virt::StopVp;
 use virt::VpHaltReason;
+use virt::VpHaltReasonKind;
 use virt::VpIndex;
 use virt::io::CpuIo;
 use virt::irqcon::MsiRequest;
@@ -1381,7 +1382,7 @@ impl virt::Processor for MshvProcessor<'_> {
             match vcpufd.run() {
                 Ok(exit) => match HvMessageType(exit.header.message_type) {
                     HvMessageType::HvMessageTypeUnrecoverableException => {
-                        return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
+                        return Err(VpHaltReasonKind::TripleFault { vtl: Vtl::Vtl0 }.into());
                     }
                     HvMessageType::HvMessageTypeX64IoPortIntercept => {
                         self.handle_io_port_intercept(&exit, dev).await?;

--- a/vmm_core/virt_support_aarch64emu/src/emulate.rs
+++ b/vmm_core/virt_support_aarch64emu/src/emulate.rs
@@ -18,6 +18,7 @@ use hvdef::HvInterceptAccessType;
 use hvdef::HvMapGpaFlags;
 use thiserror::Error;
 use virt::VpHaltReason;
+use virt::VpHaltReasonKind;
 use virt::io::CpuIo;
 use vm_topology::processor::VpIndex;
 use zerocopy::FromBytes;
@@ -174,7 +175,7 @@ pub async fn emulate<T: EmulatorSupport>(
 ) -> Result<(), VpHaltReason> {
     emulate_core(support, intercept_state, emu_mem, dev)
         .await
-        .map_err(|e| VpHaltReason::EmulationFailure(e.into()))
+        .map_err(|e| VpHaltReasonKind::EmulationFailure(e.into()).into())
 }
 
 async fn emulate_core<T: EmulatorSupport>(

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -13,6 +13,7 @@ use hvdef::HvInterceptAccessType;
 use hvdef::HvMapGpaFlags;
 use thiserror::Error;
 use virt::VpHaltReason;
+use virt::VpHaltReasonKind;
 use virt::io::CpuIo;
 use vm_topology::processor::VpIndex;
 use x86defs::Exception;
@@ -296,7 +297,7 @@ pub async fn emulate<T: EmulatorSupport>(
 ) -> Result<(), VpHaltReason> {
     emulate_core(support, emu_mem, dev)
         .await
-        .map_err(|e| VpHaltReason::EmulationFailure(e.into()))
+        .map_err(|e| VpHaltReasonKind::EmulationFailure(e.into()).into())
 }
 
 async fn emulate_core<T: EmulatorSupport>(
@@ -515,7 +516,7 @@ pub async fn emulate_insn_memory_op<T: EmulatorSupport>(
             emu.write_memory(segment, gva, alignment, data).await
         }
     }
-    .map_err(|e| VpHaltReason::EmulationFailure(e.into()))
+    .map_err(|e| VpHaltReasonKind::EmulationFailure(e.into()).into())
 
     // No need to flush the cache, we have not modified any registers.
 }


### PR DESCRIPTION
The intention behind this change is to provide better crash stacks and dumps in ICMs. By panicking at the point of error construction, rather than after the error has bubbled up to a higher layer, we are better able to capture context around the cause of the failure and to provide a meaningful stack to Watson (instead of just blaming the HaltRequest::Panic handler for all these different error sources).

However the ability to keep a VM 'alive' for inspection after a failure is still useful, and we want to preserve it. Therefore this change makes this behavior configurable. Currently we set this immediate panic behavior on release builds (so it will affect prod and ICMs by default), while preserving the current behavior for debug builds (so it won't affect local testing scenarios by default). We can add a command line parameter for this too if desired, or other switches.